### PR TITLE
feat: finalize auto-version bumping

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,5 @@
+plugins: [
+  "@semantic-release/commit-analyzer",
+  '@semantic-release/release-notes-generator',
+  "@semantic-release/github"
+]


### PR DESCRIPTION
Adding a missing file. Previously we would use the default release plugins which would also try to publish to NPM by default
