### PR TITLE
fix(auth): only configure OAuth token getter with credentials

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,38 +29,43 @@ type Client struct {
 
 func NewClient(opts ...option.RequestOption) *Client {
 	options := core.NewRequestOptions(opts...)
-	oauthTokenProvider := core.NewTokenProvider(
-		0,
-	)
+
+	oauthTokenProvider := core.NewTokenProvider(0)
+
 	authOptions := *options
-	authClient := oauth.NewClient(
-		&authOptions,
-	)
-	options.SetTokenGetter(func() (string, error) {
-		return oauthTokenProvider.GetOrFetch(func() (string, int, error) {
-			response, err := authClient.GetToken(context.Background(), &Lattice.GetTokenRequest{
-				ClientID: Lattice.String(
-					options.ClientID,
-				),
-				ClientSecret: Lattice.String(
-					options.ClientSecret,
-				),
+	authClient := oauth.NewClient(&authOptions)
+
+	if options.ClientID != "" || options.ClientSecret != "" {
+		options.SetTokenGetter(func() (string, error) {
+			return oauthTokenProvider.GetOrFetch(func() (string, int, error) {
+				response, err := authClient.GetToken(context.Background(), &Lattice.GetTokenRequest{
+					ClientID: Lattice.String(
+						options.ClientID,
+					),
+					ClientSecret: Lattice.String(
+						options.ClientSecret,
+					),
+				})
+				if err != nil {
+					return "", 0, err
+				}
+
+				if response.AccessToken == "" {
+					return "", 0, errors.New(
+						"oauth response missing access token",
+					)
+				}
+
+				expiresIn := core.DefaultExpirySeconds
+				if response.ExpiresIn != nil {
+					expiresIn = *response.ExpiresIn
+				}
+
+				return response.AccessToken, expiresIn, nil
 			})
-			if err != nil {
-				return "", 0, err
-			}
-			if response.AccessToken == "" {
-				return "", 0, errors.New(
-					"oauth response missing access token",
-				)
-			}
-			expiresIn := core.DefaultExpirySeconds
-			if response.ExpiresIn != nil {
-				expiresIn = *response.ExpiresIn
-			}
-			return response.AccessToken, expiresIn, nil
 		})
-	})
+	}
+
 	return &Client{
 		Entities: entities.NewClient(options),
 		Tasks:    tasks.NewClient(options),


### PR DESCRIPTION
This change updates client initialization so the OAuth token getter is only configured when client credentials are present. Previously, the client could be wired into the OAuth token retrieval path even in setups that were using an explicit bearer token, a custom Authorization header, or no authentication at all for testing. 

Restricting the token getter to credential backed clients keeps those other authentication paths from being forced through unnecessary OAuth behavior.

OAuth backed authentication is still fully supported when a client ID or client secret is configured. In that case, the token getter continues to use the shared token provider, checks that the OAuth response includes an access token, and preserves the existing expiration handling based on the response’s expires-in value.

This makes authentication behavior more predictable across different client configurations. Clients that are configured for OAuth still fetch and cache OAuth tokens as before, while clients that are not configured with client credentials avoid unnecessary token requests and rely on their explicitly provided authentication settings.

Cheers,
Michael