### PR TITLE
test(auth): cover request header token behavior

### DIFF
--- a/core/request_option_test.go
+++ b/core/request_option_test.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRequestOptions_ToHeaderReturnsTokenGetterError(t *testing.T) {
+	expectedErr := errors.New("token fetch failed")
+
+	options := NewRequestOptions()
+	options.SetTokenGetter(func() (string, error) {
+		return "", expectedErr
+	})
+
+	_, err := options.ToHeader()
+	if err == nil {
+		t.Fatal("expected ToHeader to return token getter error")
+	}
+
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error to wrap token getter error, got %v", err)
+	}
+}
+
+func TestRequestOptions_ToHeaderSetsBearerTokenFromTokenGetter(t *testing.T) {
+	options := NewRequestOptions()
+	options.SetTokenGetter(func() (string, error) {
+		return "test-token", nil
+	})
+
+	headers, err := options.ToHeader()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got := headers.Get("Authorization"); got != "Bearer test-token" {
+		t.Fatalf("expected Authorization header %q, got %q", "Bearer test-token", got)
+	}
+}
+
+func TestRequestOptions_ToHeaderExplicitTokenTakesPrecedence(t *testing.T) {
+	options := NewRequestOptions(&TokenOption{Token: "explicit-token"})
+	options.SetTokenGetter(func() (string, error) {
+		return "oauth-token", nil
+	})
+
+	headers, err := options.ToHeader()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got := headers.Get("Authorization"); got != "Bearer explicit-token" {
+		t.Fatalf("expected explicit Authorization header %q, got %q", "Bearer explicit-token", got)
+	}
+}


### PR DESCRIPTION
This change adds unit coverage for `RequestOptions.ToHeader` when authentication headers are built from either an OAuth token getter or an explicitly configured bearer token. The tests verify that token getter failures are returned to the caller instead of being ignored, which protects against silently sending unauthenticated requests when OAuth token retrieval fails.

The new tests also verify the successful token getter path by confirming that a returned OAuth token is written to the Authorization header using the expected bearer-token format. This ensures the normal OAuth-backed header construction behavior continues to work after changing ToHeader to return errors.

Finally, the tests confirm that an explicitly configured bearer token takes precedence over the OAuth token getter. This preserves the expected authentication override behavior for clients that provide a direct token while still allowing OAuth-backed clients to retrieve tokens dynamically.

Cheers,
Michael Mendy