### PR TITLE
chore(auth): add script to patch generated header call sites

### DIFF
--- a/scripts/patch-auth-header-call-sites.py
+++ b/scripts/patch-auth-header-call-sites.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import re
+from pathlib import Path
+
+FILES = [
+    "entities/raw_client.go",
+    "entities/client.go",
+    "objects/raw_client.go",
+    "objects/client.go",
+    "tasks/raw_client.go",
+    "tasks/client.go",
+    "oauth/raw_client.go",
+]
+
+PATTERN = re.compile(
+    r"(?m)^(\t*)headers := internal\.MergeHeaders\(\n"
+    r"\1\t([rc])\.options\.ToHeader\(\),\n"
+    r"\1\toptions\.ToHeader\(\),\n"
+    r"\1\)"
+)
+
+
+def replacement(match: re.Match) -> str:
+    indent = match.group(1)
+    receiver = match.group(2)
+
+    return (
+        f"{indent}headers, err := internal.MergeRequestHeaders({receiver}.options, options)\n"
+        f"{indent}if err != nil {{\n"
+        f"{indent}\treturn nil, err\n"
+        f"{indent}}}"
+    )
+
+
+def main() -> None:
+    changed = []
+
+    for filename in FILES:
+        path = Path(filename)
+        original = path.read_text()
+        updated, count = PATTERN.subn(replacement, original)
+
+        if count == 0:
+            raise SystemExit(f"no header call sites patched in {filename}")
+
+        path.write_text(updated)
+        changed.append((filename, count))
+
+    for filename, count in changed:
+        print(f"patched {count} call site(s) in {filename}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change adds a temporary helper script for updating generated client files to use MergeRequestHeaders instead of calling ToHeader inline through MergeHeaders. The script targets the generated entity, object, task, and OAuth clients, replacing each matching header merge block with error-aware request header construction.

This is needed because ToHeader can now return an error when header construction fails, including when OAuth token retrieval fails. Updating the generated call sites ensures those errors are propagated back to the caller instead of being hidden during request creation.

The script also fails fast when a target file does not contain the expected call-site pattern. That makes it safer to run during the transition because it avoids silently skipping generated files that may still need to be patched.

Cheers,
Michael Mendy 